### PR TITLE
Order the transactions globally instead of clustered per network

### DIFF
--- a/Code.ts
+++ b/Code.ts
@@ -59,16 +59,16 @@ function importNetworkTransactions(address : string, network : string, index : n
   var header: Array<string> = input.shift();
   var output: Array<Array<string>> = [];
 
-
   // TODO(filipe): Find a better way here. A little hacky in order to only output the header once.
   if (index == 0) {
     output.push(["Network", ...header]);
   }
 
-  Logger.log(`Processing network : ${network}, entries: ${output.length}`);
+  for (let e of input) {
+    output.push([network, ...e]);
+  }
 
-  return input
-      .map(x => [network, ...x]); // Add Network as the first column.
+  return output;
 }
 
 const noFilter = (x : string) => x;


### PR DESCRIPTION
Previously the code was ordering the transactions per network block instead of globally, which really isn't something you would naturally expect. This PR orders transactions globally.

The code is a little lambda heavy which has its readability disadvantage. That said since most of the logic in this class are filters and transformation, I suspect the more functional approach is actually beneficial, but happy to hear counter-arguments.

Closes #3